### PR TITLE
Feature: periodic server kill for `verify` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -802,6 +802,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -950,6 +959,7 @@ dependencies = [
  "mio",
  "num_cpus",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.48.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.11"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2e1ebcb11de5c03c67de28a7df593d32191b44939c482e97702baaaa6ab6a5"
+checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -42,9 +42,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2faccea4cc4ab4a667ce676a30e8ec13922a692c99bb8f5b11f1502c72e04220"
+checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
 
 [[package]]
 name = "anstyle-parse"
@@ -76,9 +76,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.79"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
+checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
 
 [[package]]
 name = "autocfg"
@@ -115,9 +115,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bumpalo"
-version = "3.14.0"
+version = "3.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+checksum = "8ea184aa71bb362a1157c896979544cc23974e08fd265f29ea96b59f0b4a555b"
 
 [[package]]
 name = "bytes"
@@ -127,12 +127,9 @@ checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
-dependencies = [
- "libc",
-]
+checksum = "a0ba8f7aaa012f30d5b2861462f6708eccd49c3c39863fe083a308035f63d723"
 
 [[package]]
 name = "cfg-if"
@@ -142,9 +139,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.4.18"
+version = "4.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
+checksum = "c918d541ef2913577a0f9566e9ce27cb35b6df072075769e0b26cb5a554520da"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -152,9 +149,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.18"
+version = "4.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
+checksum = "9f3e7391dad68afb0c2ede1bf619f579a3dc9c2ec67f089baa397123a2f3d1eb"
 dependencies = [
  "anstream",
  "anstyle",
@@ -164,9 +161,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.4.7"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
+checksum = "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -176,9 +173,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "colorchoice"
@@ -342,15 +339,15 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.4"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d3d0e0f38255e7fa3cf31335b3a56f05febd18025f4db5ef7a0cfb4f8da651f"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "http"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8947b1a6fad4393052c7ba1f4cd97bed3e953a95c79c92ad9b051a04611d9fbb"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
 dependencies = [
  "bytes",
  "fnv",
@@ -430,9 +427,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.2"
+version = "2.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824b2ae422412366ba479e8111fd301f7b5faece8149317bb81925979a53f520"
+checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -452,9 +449,9 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.67"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a1d36f1235bc969acba30b7f5990b864423a6068a10f7c90ae8f0112e3a59d1"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -473,9 +470,9 @@ checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "memchr"
@@ -491,18 +488,18 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
 dependencies = [
  "adler",
 ]
 
 [[package]]
 name = "mio"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "wasi",
@@ -684,16 +681,17 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.7"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "688c63d65483050968b2a8937f7995f443e27041a0f7700aa59b0822aedebb74"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
+ "cfg-if",
  "getrandom",
  "libc",
  "spin",
  "untrusted",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -735,9 +733,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
+checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 
 [[package]]
 name = "sct"
@@ -751,18 +749,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.196"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.196"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
+checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -771,9 +769,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.113"
+version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
+checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
 dependencies = [
  "itoa",
  "ryu",
@@ -827,12 +825,12 @@ checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "socket2"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
+checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -860,15 +858,15 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "2.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -904,18 +902,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
+checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
+checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -924,9 +922,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.7"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -949,9 +947,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.35.1"
+version = "1.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89b4efa943be685f629b149f53829423f8f5531ea21249408e8e2f8671ec104"
+checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
 dependencies = [
  "backtrace",
  "bytes",
@@ -1083,9 +1081,9 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
 dependencies = [
  "tinyvec",
 ]
@@ -1142,9 +1140,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.90"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1223296a201415c7fad14792dbefaace9bd52b62d33453ade1c5b5f07555406"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -1152,9 +1150,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.90"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcdc935b63408d58a32f8cc9738a0bffd8f05cc7c002086c6ef20b7312ad9dcd"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
 dependencies = [
  "bumpalo",
  "log",
@@ -1167,9 +1165,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.40"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bde2032aeb86bdfaecc8b261eef3cba735cc426c1f3a3416d1e0791be95fc461"
+checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1179,9 +1177,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.90"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e4c238561b2d428924c49815533a8b9121c664599558a5d9ec51f8a1740a999"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1189,9 +1187,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.90"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bae1abb6806dc1ad9e560ed242107c0f6c84335f1749dd4e8ddb012ebd5e25a7"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1202,15 +1200,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.90"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d91413b1c31d7539ba5ef2451af3f0b833a005eb27a631cec32bc0635a8602b"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "web-sys"
-version = "0.3.67"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58cd2333b6e0be7a39605f0e255892fd7418a682d8da8fe042fe25128794d2ed"
+checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1218,9 +1216,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.25.3"
+version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1778a42e8b3b90bff8d0f5032bf22250792889a5cdc752aa0020c84abe3aaf10"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "winapi"
@@ -1259,7 +1257,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -1279,17 +1277,17 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.0",
- "windows_aarch64_msvc 0.52.0",
- "windows_i686_gnu 0.52.0",
- "windows_i686_msvc 0.52.0",
- "windows_x86_64_gnu 0.52.0",
- "windows_x86_64_gnullvm 0.52.0",
- "windows_x86_64_msvc 0.52.0",
+ "windows_aarch64_gnullvm 0.52.4",
+ "windows_aarch64_msvc 0.52.4",
+ "windows_i686_gnu 0.52.4",
+ "windows_i686_msvc 0.52.4",
+ "windows_x86_64_gnu 0.52.4",
+ "windows_x86_64_gnullvm 0.52.4",
+ "windows_x86_64_msvc 0.52.4",
 ]
 
 [[package]]
@@ -1300,9 +1298,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1312,9 +1310,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1324,9 +1322,9 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1336,9 +1334,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1348,9 +1346,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1360,9 +1358,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1372,9 +1370,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 anyhow = "1.0.79"
 thiserror = "1.0.56"
 reqwest = { version = "0.11.23", default-features = false, features = ["rustls-tls"] }
-tokio = { version = "1.35.1", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.35.1", features = ["macros", "rt-multi-thread", "process"] }
 clap = { version = "4.4.18", features = ["derive", "string"] }
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,14 +6,14 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.79"
-thiserror = "1.0.56"
+anyhow = "1.0.80"
+thiserror = "1.0.57"
 reqwest = { version = "0.11.23", default-features = false, features = ["rustls-tls"] }
-tokio = { version = "1.35.1", features = ["macros", "rt-multi-thread", "process"] }
-clap = { version = "4.4.18", features = ["derive", "string"] }
+tokio = { version = "1.36.0", features = ["macros", "rt-multi-thread", "process"] }
+clap = { version = "4.5.1", features = ["derive", "string"] }
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
 prettydiff = { version = "0.6.4", default-features = false }
 rand = "0.8.5"
 csv = "1.3.0"
-serde = { version = "1.0.195", features = ["derive"] }
+serde = { version = "1.0.197", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ transaction implementation of the triplestore. It does this by stressing the tri
 a number of readers while simultaneously performing concurrent updates. After each update the tool verifies that
 the update was applied correctly.
 
+To explicitly test durability use `verify` with `--kill-script`, `--start-script` and `--restart-script`.
+In this mode the test will periodically kill and restart the server to ensure transactional durability.
+
+For best test coverage it is advisable to run both `verify` twice, once with and once without the
+previously named options.
+
 To generate the known-correct data, use `generate_update_operations.sh`.
 Or use one of the pre-generated, swdf-based sets provided in `rdf_small/` and `rdf_large/`.
 
@@ -31,5 +37,13 @@ Or use one of the pre-generated, swdf-based sets provided in `rdf_small/` and `r
 
 # 4  write workers using pre-generated data from rdf_large/
 # 24 read workers using the queries from queries.txt to stress the triplestore
-cargo run --release -- verify -w 4 -Q rdf_large -r 24 -q queries.txt http://localhost:9080/sparql http://localhost:9080/update
+cargo run --release -- verify -w 4 -Q rdf_large -r 24 -q queries.txt \
+    http://localhost:9080/sparql http://localhost:9080/update
+
+# 4  write workers using pre-generated data from rdf_large/
+# 24 read workers using the queries from queries.txt to stress the triplestore
+# using given scripts to perform server lifecycle management
+cargo run --release -- verify -w 4 -Q rdf_large -r 24 -q queries.txt \
+    --start-script examples/start.sh --kill-script examples/kill.sh --restart-script examples/restart.sh \
+    http://localhost:9080/sparql http://localhost:9080/update
 ```

--- a/examples/kill.sh
+++ b/examples/kill.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Kill all tentris instances (must not have other tentris instances running)
+killall -s SIGKILL tentris

--- a/examples/restart.sh
+++ b/examples/restart.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Rollback, ignore error in last log entry (assumption: no bit-rot / hardware failure / disk corruption)
+tentris rollback --use-latest-auto-snapshot --replay --ignore-error-in-last-log-entry
+tentris serve & disown
+
+sleep 2

--- a/examples/start.sh
+++ b/examples/start.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Clean start
+rm -rf tentris-data
+tentris load < swdf.nt
+tentris serve & disown
+
+sleep 2

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,7 @@
-use std::fmt::{Display, Formatter};
+use std::{
+    fmt::{Display, Formatter},
+    io,
+};
 use thiserror::Error;
 
 #[derive(Debug)]
@@ -33,6 +36,8 @@ pub enum WorkerError {
         err: reqwest::Error,
         verbose_info: Option<UpdateFailedVerboseInfo>,
     },
+    KillFailed(io::Error),
+    RestartFailed(io::Error),
 }
 
 fn format_insert_or_delete_data(f: &mut Formatter<'_>, q: &str) -> std::fmt::Result {
@@ -93,6 +98,8 @@ impl Display for WorkerError {
                     "A reader was unable to execute a query. Error: {err}\nQuery: {query}"
                 )
             },
+            WorkerError::KillFailed(err) => write!(f, "Unable to kill server. Error: {err}"),
+            WorkerError::RestartFailed(err) => write!(f, "Unable to restart server. Error: {err}"),
         }
     }
 }

--- a/src/kill_worker.rs
+++ b/src/kill_worker.rs
@@ -1,0 +1,58 @@
+use crate::error::WorkerError;
+use std::{
+    ffi::{OsStr, OsString},
+    io,
+    sync::Arc,
+    time::Duration,
+};
+use tokio::{process::Command, sync::Notify};
+
+pub struct KillWorker {
+    kill_script: OsString,
+    restart_script: OsString,
+    kill_delay: Duration,
+}
+
+impl KillWorker {
+    pub fn new<OS: AsRef<OsStr>>(kill_script: OS, restart_script: OS, kill_delay: Duration) -> Self {
+        Self {
+            kill_script: kill_script.as_ref().to_owned(),
+            restart_script: restart_script.as_ref().to_owned(),
+            kill_delay,
+        }
+    }
+
+    async fn run_command(script: &OsStr, map_err: impl Fn(io::Error) -> WorkerError) -> Result<(), WorkerError> {
+        let mut child = Command::new("sh").arg("-c").arg(script).spawn().map_err(&map_err)?;
+
+        let status = child.wait().await.map_err(&map_err)?;
+        if status.success() {
+            Ok(())
+        } else {
+            Err(map_err(io::Error::new(io::ErrorKind::Other, "Exit code != 0")))
+        }
+    }
+
+    async fn kill(&self) -> Result<(), WorkerError> {
+        Self::run_command(&self.kill_script, WorkerError::KillFailed).await
+    }
+
+    async fn restart(&self) -> Result<(), WorkerError> {
+        Self::run_command(&self.restart_script, WorkerError::RestartFailed).await
+    }
+
+    pub async fn execute(&mut self, stop: Arc<Notify>) -> Result<(), WorkerError> {
+        let worker = async {
+            loop {
+                tokio::time::sleep(self.kill_delay).await;
+                self.kill().await?;
+                self.restart().await?;
+            }
+        };
+
+        tokio::select! {
+            res = worker => res,
+            _ = stop.notified() => Ok(())
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -318,13 +318,6 @@ async fn run(opts: Command) -> anyhow::Result<()> {
         }
     }
 
-    while let Some(UpdateJobResult { worker_id, result }) = updates_finished_rx.recv().await {
-        if let Err(e) = result {
-            tracing::error!("Update worker {worker_id} encountered an error: {e}");
-            n_update_errors += 1;
-        }
-    }
-
     let end_time = tokio::time::Instant::now();
     tracing::info!(
         "All updates completed in {:.2}s, {n_update_errors} update workers encountered errors",

--- a/src/main.rs
+++ b/src/main.rs
@@ -327,7 +327,7 @@ async fn run(opts: Command) -> anyhow::Result<()> {
 
     let end_time = tokio::time::Instant::now();
     tracing::info!(
-        "All updates completed in {:.3}s, {n_update_errors} update workers encountered errors",
+        "All updates completed in {:.2}s, {n_update_errors} update workers encountered errors",
         end_time.duration_since(start_time).as_secs_f64()
     );
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,11 @@
 mod error;
+mod kill_worker;
 mod random_read_worker;
 mod update_worker;
 
 use crate::{
     error::WorkerError,
+    kill_worker::KillWorker,
     random_read_worker::{FileSourceQueryGenerator, QueryGenerator},
 };
 use clap::Parser;
@@ -11,12 +13,16 @@ use random_read_worker::{RandomLimitSelectStartQueryGenerator, RandomReadWorker}
 use reqwest::Url;
 use std::{
     collections::BTreeMap,
+    ffi::OsString,
     io::IsTerminal,
     path::{Path, PathBuf},
     sync::Arc,
     time::Duration,
 };
-use tokio::sync::{Barrier, Notify};
+use tokio::{
+    select,
+    sync::{Barrier, Notify},
+};
 use update_worker::UpdateWorker;
 
 type Query = String;
@@ -40,6 +46,16 @@ struct ReadJobResult {
     qps_measurements: Result<BTreeMap<usize, QPS>, WorkerError>,
 }
 
+struct KillJobResult {
+    result: Result<(), WorkerError>,
+}
+
+#[derive(Copy, Clone, PartialEq, Eq)]
+enum WorkerBehaviour {
+    IgnoreConnectionError,
+    ReportConnectionError,
+}
+
 #[derive(Parser)]
 struct ReaderOpts {
     /// Number of random readers to spawn
@@ -50,6 +66,29 @@ struct ReaderOpts {
     /// If not provided readers will simply run `SELECT *` with varying limits
     #[clap(short = 'q', long)]
     random_read_workers_query_file: Option<PathBuf>,
+}
+
+#[derive(Parser)]
+struct KillOpts {
+    /// TODO COMMENT
+    #[clap(long)]
+    start_script: OsString,
+
+    /// If present, the stress test will periodically
+    /// kill (i.e. uncleanly shutdown) the server using this script.
+    ///
+    /// restart_script will be used to bring it back up again to continue the test
+    /// TODO COMMENT
+    #[clap(long)]
+    kill_script: OsString,
+
+    /// The restart script corresponding to kill_script TODO COMMENT
+    #[clap(long)]
+    restart_script: OsString,
+
+    /// The number of seconds between server kills
+    #[clap(long, default_value_t = 10)]
+    kill_delay_s: u64,
 }
 
 #[derive(Parser)]
@@ -93,6 +132,9 @@ enum SubCommand {
         /// Warning the string can potentially be very long.
         #[clap(short = 'v', long)]
         verbose: bool,
+
+        #[clap(flatten)]
+        kill_opts: Option<KillOpts>,
     },
 }
 
@@ -122,10 +164,12 @@ async fn main() {
 }
 
 async fn run(opts: Command) -> anyhow::Result<()> {
-    let (update_workers, random_read_workers) = match &opts.sub {
-        SubCommand::Stress { reader_opts, query_endpoint, .. } => {
-            (vec![], make_random_readers(query_endpoint, reader_opts)?)
-        },
+    let (update_workers, random_read_workers, kill_worker) = match &opts.sub {
+        SubCommand::Stress { reader_opts, query_endpoint, .. } => (
+            vec![],
+            make_random_readers(query_endpoint, reader_opts, WorkerBehaviour::ReportConnectionError)?,
+            None,
+        ),
         SubCommand::Verify {
             reader_opts,
             num_update_workers,
@@ -133,22 +177,36 @@ async fn run(opts: Command) -> anyhow::Result<()> {
             query_endpoint,
             update_endpoint,
             verbose,
-        } => (
-            make_update_workers(
-                query_endpoint,
-                update_endpoint,
-                *num_update_workers,
-                update_query_dir,
-                *verbose,
-            )?,
-            make_random_readers(query_endpoint, reader_opts)?,
-        ),
+            kill_opts,
+        } => {
+            let behav = if kill_opts.is_none() {
+                WorkerBehaviour::ReportConnectionError
+            } else {
+                WorkerBehaviour::IgnoreConnectionError
+            };
+
+            (
+                make_update_workers(
+                    query_endpoint,
+                    update_endpoint,
+                    *num_update_workers,
+                    update_query_dir,
+                    *verbose,
+                    behav,
+                )?,
+                make_random_readers(query_endpoint, reader_opts, behav)?,
+                make_kill_worker(kill_opts.as_ref()),
+            )
+        },
     };
 
     let num_update_workers = update_workers.len();
     let num_random_read_workers = random_read_workers.len();
+    let num_kill_workers = kill_worker.is_some() as usize;
 
-    let start_barrier = Arc::new(Barrier::new(num_update_workers + num_random_read_workers + 1));
+    let start_barrier = Arc::new(Barrier::new(
+        num_update_workers + num_random_read_workers + num_kill_workers + 1,
+    ));
     let (updates_finished_tx, mut updates_finished_rx) = tokio::sync::mpsc::channel(num_update_workers);
 
     for (update_worker, worker_id) in update_workers.into_iter().zip(1..) {
@@ -184,8 +242,44 @@ async fn run(opts: Command) -> anyhow::Result<()> {
         });
     }
 
+    let (kill_worker_finished_tx, mut kill_worker_finished_rx) = tokio::sync::mpsc::channel(1);
+
+    if let Some(mut kill_worker) = kill_worker {
+        let start_barrier = start_barrier.clone();
+        let finished_tx = kill_worker_finished_tx.clone();
+        let stop_notify = stop_notify.clone();
+
+        tokio::spawn(async move {
+            start_barrier.wait().await;
+            tracing::info!("Starting kill worker");
+
+            let result = kill_worker.execute(stop_notify).await;
+            finished_tx.send(KillJobResult { result }).await.unwrap();
+        });
+    }
+
     drop(updates_finished_tx);
     drop(readers_finished_tx);
+    drop(kill_worker_finished_tx);
+
+    if let SubCommand::Verify { kill_opts: Some(KillOpts { start_script, .. }), .. } = &opts.sub {
+        match tokio::process::Command::new("sh")
+            .arg("-c")
+            .arg(start_script)
+            .status()
+            .await
+        {
+            Ok(status) if !status.success() => {
+                tracing::error!("Starting server failed. Error: Script returned exit status != 0");
+                return Err(anyhow::anyhow!("Test failed, unable to perform lifecycle management"));
+            },
+            Err(e) => {
+                tracing::error!("Starting server failed. Error: {e}");
+                return Err(anyhow::anyhow!("Test failed, unable to perform lifecycle management"));
+            },
+            _ => (),
+        }
+    }
 
     start_barrier.wait().await;
     let start_time = tokio::time::Instant::now();
@@ -196,6 +290,29 @@ async fn run(opts: Command) -> anyhow::Result<()> {
     }
 
     let mut n_update_errors = 0;
+
+    loop {
+        select! {
+            ujobres = updates_finished_rx.recv() => {
+                if let Some(UpdateJobResult { worker_id, result }) = ujobres {
+                    if let Err(e) = result {
+                        tracing::error!("Update worker {worker_id} encountered an error: {e}");
+                        n_update_errors += 1;
+                    }
+                } else {
+                    break;
+                }
+            },
+            kjobres = kill_worker_finished_rx.recv() => {
+                if let Some(KillJobResult { result }) = kjobres {
+                    if let Err(e) = result {
+                        tracing::error!("Kill worker encountered an error: {e}");
+                        return Err(anyhow::anyhow!("Test failed, unable to perform lifecycle management"));
+                    }
+                }
+            },
+        }
+    }
 
     while let Some(UpdateJobResult { worker_id, result }) = updates_finished_rx.recv().await {
         if let Err(e) = result {
@@ -240,6 +357,10 @@ async fn run(opts: Command) -> anyhow::Result<()> {
         qps_sum / num_random_read_workers as f64,
     );
 
+    if let SubCommand::Verify { kill_opts: Some(KillOpts { kill_script, .. }), .. } = &opts.sub {
+        let _ = tokio::process::Command::new("sh").arg("-c").arg(kill_script).spawn();
+    }
+
     if n_update_errors > 0 {
         Err(anyhow::anyhow!("Test failed, errors were encountered"))
     } else {
@@ -247,9 +368,16 @@ async fn run(opts: Command) -> anyhow::Result<()> {
     }
 }
 
+fn make_kill_worker(kill_opts: Option<&KillOpts>) -> Option<KillWorker> {
+    kill_opts.map(|KillOpts { kill_script, restart_script, kill_delay_s, .. }| {
+        KillWorker::new(kill_script, restart_script, Duration::from_secs(*kill_delay_s))
+    })
+}
+
 fn make_random_readers(
     query_endpoint: &Url,
     ReaderOpts { num_random_read_workers, random_read_workers_query_file }: &ReaderOpts,
+    behav: WorkerBehaviour,
 ) -> anyhow::Result<Vec<RandomReadWorker>> {
     let mut random_read_workers = Vec::with_capacity(*num_random_read_workers);
     for _ in 0..*num_random_read_workers {
@@ -259,7 +387,7 @@ fn make_random_readers(
             Box::new(RandomLimitSelectStartQueryGenerator)
         };
 
-        let w = RandomReadWorker::new(query_gen, query_endpoint.clone());
+        let w = RandomReadWorker::new(query_gen, query_endpoint.clone(), behav);
         random_read_workers.push(w);
     }
 
@@ -272,6 +400,7 @@ fn make_update_workers(
     num_update_workers: usize,
     query_dir: &Path,
     verbose: bool,
+    behav: WorkerBehaviour,
 ) -> anyhow::Result<Vec<UpdateWorker>> {
     let mut update_workers = Vec::with_capacity(num_update_workers);
     for worker in 1..=num_update_workers {
@@ -280,6 +409,7 @@ fn make_update_workers(
             query_endpoint.clone(),
             update_endpoint.clone(),
             verbose,
+            behav,
         )?;
 
         update_workers.push(w);

--- a/src/main.rs
+++ b/src/main.rs
@@ -327,8 +327,8 @@ async fn run(opts: Command) -> anyhow::Result<()> {
 
     let end_time = tokio::time::Instant::now();
     tracing::info!(
-        "All updates completed in {}ms, {n_update_errors} update workers encountered errors",
-        end_time.duration_since(start_time).as_millis()
+        "All updates completed in {:.3}s, {n_update_errors} update workers encountered errors",
+        end_time.duration_since(start_time).as_secs_f64()
     );
 
     stop_notify.notify_waiters();

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,19 +70,23 @@ struct ReaderOpts {
 
 #[derive(Parser)]
 struct KillOpts {
-    /// TODO COMMENT
+    /// If present, the stress test will use this script to start the server on test begin.
+    ///
+    /// This option must be used in conjunction with --kill-script and --restart-script.
     #[clap(long)]
     start_script: OsString,
 
     /// If present, the stress test will periodically
     /// kill (i.e. uncleanly shutdown) the server using this script.
     ///
-    /// restart_script will be used to bring it back up again to continue the test
-    /// TODO COMMENT
+    /// This option must be used in conjunction with --start-script and --restart-script.
     #[clap(long)]
     kill_script: OsString,
 
-    /// The restart script corresponding to kill_script TODO COMMENT
+    /// If present, the stress test will restart the server
+    /// after a kill using this script.
+    ///
+    /// This option must be used in conjunction with --start-script and --kill-script.
     #[clap(long)]
     restart_script: OsString,
 


### PR DESCRIPTION
Implements a feature for transactional durability testing.
Adds new options that must be used in conjunction `--kill-script`, `--start-script` and `--restart-script`.

If these options are present `sparql-transactional-test` will perform server lifecycle management by itself. 

Additionally, the `verify` test procedure will be altered to include a worker that will periodically uncleanly shut down the server and then attempt to restart it.

The test is considered "passed" if the server does not loose any data (all data from confirmed successful updates is still there) and the server is able to continue to operate normally after the restart.

Important note: This test is not a replacement for the normal `verify` command (without the additional options). Due to the nature of this test the workers will (and have to) tolerate connection errors, which the normal version of the test does not tolerate.